### PR TITLE
feat: add JMH benchmarks for Phase 5 performance measurement

### DIFF
--- a/cache-engine/pom.xml
+++ b/cache-engine/pom.xml
@@ -20,6 +20,43 @@
             <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
+        <!-- JMH for Phase 5 performance benchmarks -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.37</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.37</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Run JMH with: mvn test-compile exec:java (use exec:java, not exec:exec) -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <classpathScope>test</classpathScope>
+                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                    <arguments>
+                        <argument>-f</argument>
+                        <argument>0</argument>
+                        <argument>-wi</argument>
+                        <argument>3</argument>
+                        <argument>-i</argument>
+                        <argument>3</argument>
+                        <argument>org.jerome.benchmark.LRUCacheBenchmark</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/cache-engine/src/main/java/org/jerome/LRUCache.java
+++ b/cache-engine/src/main/java/org/jerome/LRUCache.java
@@ -38,7 +38,7 @@ public class LRUCache<K, V> {
     int capacityMin = 1;
     long capacityMax = 1_000_000L;
 
-    LRUCache(int capacity){
+    public LRUCache(int capacity){
         if (capacity < capacityMin || capacity > capacityMax){
             throw new IllegalArgumentException("Capacity must be greater than 1 and not greather than" + capacityMax);
         }

--- a/cache-engine/src/test/java/org/jerome/benchmark/LRUCacheBenchmark.java
+++ b/cache-engine/src/test/java/org/jerome/benchmark/LRUCacheBenchmark.java
@@ -1,0 +1,82 @@
+package org.jerome.benchmark;
+
+import org.jerome.LRUCache;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Phase 5 — Performance measurement for LRUCache.
+ *
+ * Metrics: ops/sec (throughput), latency (p95/p99 with -bm sampletime), thread scaling (-t N).
+ *
+ * Run from cache-engine:
+ *   mvn test-compile exec:java
+ *
+ * Run one benchmark (e.g. readHeavy) with 8 threads and latency mode:
+ *   mvn test-compile exec:exec -Dexec.args="-f 1 -wi 3 -i 3 -t 8 -bm sampletime -tu us org.jerome.benchmark.LRUCacheBenchmark.readHeavy"
+ *
+ * Thread scaling: run with -t 1, -t 2, -t 4, -t 8 and record ops/sec.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 3, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class LRUCacheBenchmark {
+
+    private static final int CAPACITY = 10_000;
+    /** Key space larger than capacity to trigger evictions in write-heavy workload */
+    private static final int KEY_SPACE = 100_000;
+
+    private LRUCache<Integer, String> cache;
+    private int[] readKeyIndices;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        cache = new LRUCache<>(CAPACITY);
+        for (int i = 0; i < CAPACITY; i++) {
+            cache.put(i, "v" + i);
+        }
+        readKeyIndices = new int[CAPACITY];
+        for (int i = 0; i < CAPACITY; i++) {
+            readKeyIndices[i] = i;
+        }
+    }
+
+    /** Read-heavy: 100% get from existing keys. Use -t 1,2,4,8 for thread scaling. */
+    @Benchmark
+    @Threads(4)
+    public void readHeavy(Blackhole bh) {
+        int idx = ThreadLocalRandom.current().nextInt(readKeyIndices.length);
+        String v = cache.get(readKeyIndices[idx]);
+        bh.consume(v);
+    }
+
+    /** Write-heavy: 100% put with keys in [0, KEY_SPACE) to trigger eviction. */
+    @Benchmark
+    @Threads(4)
+    public void writeHeavy(Blackhole bh) {
+        int key = ThreadLocalRandom.current().nextInt(KEY_SPACE);
+        cache.put(key, "v" + key);
+        bh.consume(key);
+    }
+
+    /** Mixed: 50% get, 50% put. */
+    @Benchmark
+    @Threads(4)
+    public void mixed(Blackhole bh) {
+        if (ThreadLocalRandom.current().nextBoolean()) {
+            int idx = ThreadLocalRandom.current().nextInt(readKeyIndices.length);
+            String v = cache.get(readKeyIndices[idx]);
+            bh.consume(v);
+        } else {
+            int key = ThreadLocalRandom.current().nextInt(KEY_SPACE);
+            cache.put(key, "v" + key);
+            bh.consume(key);
+        }
+    }
+}


### PR DESCRIPTION
- Add JMH dependencies (jmh-core, jmh-generator-annprocess 1.37)
- Add exec-maven-plugin for running benchmarks
- Create LRUCacheBenchmark with readHeavy, writeHeavy, mixed workloads
- Make LRUCache constructor public for benchmark access